### PR TITLE
generic generate goal #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This maven plugin is a wrapper around the [rdl binary tool](https://github.com/a
 use this plugin to generate java source files from rdl files defined within the project.
 [RDL](https://ardielle.github.io/) is a formal language for defining restful resources.
 
-The `:generate-jax-rs-resources` goal generates jax-rs resources from a project's rdl files.
+The `:generate` goal generates java code from a project's rdl files.
 
 ```
-mvn rdl:generate-jax-rs-resources
+mvn rdl:generate
 ```
 
 It is simply a wrapper around `rdl generate java-model` and `rdl generate java-server`.
@@ -33,16 +33,42 @@ Usage
                 <version>1.14.6</version>
                 <configuration>
                     <rdlDirectory>${project.build.resources[0].directory}/rdl</rdlDirectory>
-                    <generatedClientDirectory>${project.build.directory}/generated-sources/rdl</generatedClientDirectory>
                     <sourceEncoding>UTF-8</sourceEncoding>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>generate-jax-rs-resources</id>
+                        <id>generate</id>
                         <phase>generate-sources</phase>
                         <goals>
-                            <goal>generate-jax-rs-resources</goal>
+                            <goal>generate</goal>
                         </goals>
+                        <configuration>
+                            <commands>
+                                <arguments>generate -o ${project.build.directory}/generated-sources/rdl java-model ${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</arguments>
+                                <arguments>generate -o ${project.build.directory}/generated-sources/rdl java-server ${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</arguments>
+                            </commands>
+                            <!-- rawCommands is equivalent to commands; only one or the other should be necessary -->  
+                            <rawCommands>
+                                <rawCommand>
+                                    <arguments>
+                                        <argument>generate</argument>
+                                        <argument>-o</argument>
+                                        <argument>${project.build.directory}/generated-sources/rdl</argument>
+                                        <argument>java-model</argument>
+                                        <argument>${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</argument>
+                                    </arguments>
+                                </rawCommand>
+                                <rawCommand>
+                                    <arguments>
+                                        <argument>generate</argument>
+                                        <argument>-o</argument>
+                                        <argument>${project.build.directory}/generated-sources/rdl</argument>
+                                        <argument>java-server</argument>
+                                        <argument>${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</argument>
+                                    </arguments>
+                                </rawCommand>
+                            </rawCommands>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -94,6 +120,7 @@ Properties
 ### rdlDirectory
 
 Specifies the folder where the `*.rdl` files are in the project source tree. Default value is `src/main/resources/rdl`.
+Ignored if `commands` or `rawCommands` are defined.
 
 ### sourceEncoding
 
@@ -104,6 +131,17 @@ to the character encoding of the rdl files.
 
 Defaults to false. If set to true, then this plugin will do nothing. Useful in the context of a multi-module
 maven project, when you want to override the inheritance of rdl-maven-plugin.
+
+### commands and rawCommands
+
+Defaults to:
+
+```
+generate -o ${project.build.directory}/generated-sources/rdl java-model src/main/resources/rdl/path/to/spec.rdl
+generate -o ${project.build.directory}/generated-sources/rdl java-server src/main/resources/rdl/path/to/spec.rdl
+```
+
+Specifies the arguments that will be passed to the rdl binary. `commands` is split by [maven-utils](https://maven.apache.org/shared/maven-shared-utils/apidocs/org/apache/maven/shared/utils/cli/CommandLineUtils.html#translateCommandline). Use `rawCommands` instead if you need more precise control on the split.
 
 Building
 --------

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,11 @@ Licensed under the terms of the Apache version 2.0 license. See LICENSE file for
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.0.24</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>1.9.5</version>

--- a/src/it/client-it/invoker.properties
+++ b/src/it/client-it/invoker.properties
@@ -1,0 +1,3 @@
+# Copyright 2016 Yahoo Inc.
+# Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+invoker.buildResult=success

--- a/src/it/client-it/pom.xml
+++ b/src/it/client-it/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2016 Yahoo Inc.
+Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.yahoo.rdl.it</groupId>
+    <artifactId>client-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Verify that generated resource files compile successfully</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.6</source> <!-- because Android -->
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <rawCommands>
+                                <rawCommand>
+                                    <arguments>
+                                        <argument>generate</argument>
+                                        <argument>-o</argument>
+                                        <argument>${project.build.directory}/generated-sources/rdl</argument>
+                                        <argument>java-client</argument>
+                                        <argument>${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</argument>
+                                    </arguments>
+                                </rawCommand>
+                            </rawCommands>
+                            <commands>
+                                <arguments>generate -o ${project.build.directory}/generated-sources/rdl java-model ${project.build.resources[0].directory}/rdl/com/yahoo/assets.rdl</arguments>
+                            </commands>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.rdl</groupId>
+            <artifactId>rdl-java</artifactId>
+            <version>1.4.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>9.2.2.v20140723</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>2.22.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/client-it/src/main/resources/rdl/com/yahoo/assets.rdl
+++ b/src/it/client-it/src/main/resources/rdl/com/yahoo/assets.rdl
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+name ApiResources;
+namespace com;
+
+type ApiAssetsRespObject Struct {
+
+}
+
+// uploadAsset();
+// Asset data is expected in the post request body.
+// Typically, the client will POST to /groups/{groupId}/events
+// immediately after calling this endpoint, using the assetId returned as a query string parameter.
+resource ApiAssetsRespObject POST "/api/v1/assets?height={height}&width={width}&sourceUrl={sourceUrl}&colors={colors}&assetId={assetId}" {
+  String sourceName;
+  Int32 height (optional, default=0);
+  Int32 width (optional, default=0);
+  String sourceUrl (optional);
+  String colors (optional);
+  String assetId (optional); // Only used for uploading default assets. Mobile clients should always leave this blank.
+}

--- a/src/it/no-config-it/invoker.properties
+++ b/src/it/no-config-it/invoker.properties
@@ -1,0 +1,3 @@
+# Copyright 2016 Yahoo Inc.
+# Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+invoker.buildResult=success

--- a/src/it/no-config-it/pom.xml
+++ b/src/it/no-config-it/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Copyright 2016 Yahoo Inc.
+Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.yahoo.rdl.it</groupId>
+    <artifactId>no-config-it</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <description>Verify that generated resource files compile successfully</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.6</source> <!-- because Android -->
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.yahoo.rdl</groupId>
+            <artifactId>rdl-java</artifactId>
+            <version>1.4.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>9.2.2.v20140723</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet-core</artifactId>
+            <version>2.22.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/no-config-it/src/main/resources/rdl/com/yahoo/assets.rdl
+++ b/src/it/no-config-it/src/main/resources/rdl/com/yahoo/assets.rdl
@@ -1,0 +1,21 @@
+// Copyright 2016 Yahoo Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+name ApiResources;
+namespace com;
+
+type ApiAssetsRespObject Struct {
+
+}
+
+// uploadAsset();
+// Asset data is expected in the post request body.
+// Typically, the client will POST to /groups/{groupId}/events
+// immediately after calling this endpoint, using the assetId returned as a query string parameter.
+resource ApiAssetsRespObject POST "/api/v1/assets?height={height}&width={width}&sourceUrl={sourceUrl}&colors={colors}&assetId={assetId}" {
+  String sourceName;
+  Int32 height (optional, default=0);
+  Int32 width (optional, default=0);
+  String sourceUrl (optional);
+  String colors (optional);
+  String assetId (optional); // Only used for uploading default assets. Mobile clients should always leave this blank.
+}

--- a/src/it/no-config-it/verify.groovy
+++ b/src/it/no-config-it/verify.groovy
@@ -1,0 +1,73 @@
+// From http://stackoverflow.com/questions/159148/groovy-executing-shell-commands
+// a wrapper closure around executing a string
+// can take either a string or a list of strings (for arguments with spaces)
+// prints all output, complains and halts on error
+def runCommand = { strList ->
+    assert ( strList instanceof String ||
+            ( strList instanceof List && strList.each{ it instanceof String } ) \
+)
+    def proc = strList.execute()
+    proc.in.eachLine { line -> println line }
+    proc.out.close()
+    proc.waitFor()
+
+    print "[INFO] ( "
+    if(strList instanceof List) {
+        strList.each { print "${it} " }
+    } else {
+        print strList
+    }
+    println " )"
+
+    if (proc.exitValue()) {
+        println "gave the following error: "
+        println "[ERROR] ${proc.getErrorStream()}"
+    }
+    assert !proc.exitValue()
+}
+
+runCommand("find .");
+
+class ExistenceChecker {
+    private File basedir;
+    private String prefix;
+
+    ExistenceChecker(File basedir, String prefix) {
+        this.basedir = basedir;
+        this.prefix = prefix
+    }
+
+    public void assertExists(String f) {
+        def file = new File(basedir, prefix + f)
+        println("file: " + file)
+        assert file.isFile();
+    }
+}
+
+def generatedSourcesChecker = new ExistenceChecker(basedir, "target/generated-sources/rdl/")
+def expectedFiles = Arrays.asList(
+        "com/ApiAssetsRespObject.java",
+        "com/ApiResourcesHandler.java",
+        "com/ApiResourcesResources.java",
+        "com/ApiResourcesSchema.java",
+        "com/ApiResourcesServer.java",
+        "com/ResourceError.java",
+        "com/ResourceException.java",
+        "com/ResourceContext.java");
+for (String f : expectedFiles) {
+    generatedSourcesChecker.assertExists(f);
+}
+
+def compiledClassesChecker = new ExistenceChecker(basedir, "target/classes/");
+def expectedClassFiles = Arrays.asList(
+        "com/ApiAssetsRespObject.class",
+        "com/ApiResourcesHandler.class",
+        "com/ApiResourcesResources.class",
+        "com/ApiResourcesSchema.class",
+        "com/ApiResourcesServer.class",
+        "com/ResourceError.class",
+        "com/ResourceException.class",
+        "com/ResourceContext.class");
+for (String f : expectedClassFiles) {
+    compiledClassesChecker.assertExists(f);
+}

--- a/src/main/java/com/yahoo/rdl/maven/GenerateMojo.java
+++ b/src/main/java/com/yahoo/rdl/maven/GenerateMojo.java
@@ -1,0 +1,141 @@
+//Copyright 2016 Yahoo Inc.
+//Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+package com.yahoo.rdl.maven;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provides;
+import com.yahoo.rdl.maven.schema.OSName;
+import com.yahoo.rdl.maven.schema.RdlSources;
+import com.yahoo.rdl.maven.schema.ScratchSpace;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.cli.CommandLineUtils;
+
+import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Mojo( name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES )
+public class GenerateMojo extends AbstractMojo {
+
+    @Parameter( defaultValue = "${project.build.resources[0].directory}/rdl", property = "rdlDirectory", required = true )
+    private File rdlDirectory;
+
+    @Parameter(property = "rawCommands", required = false)
+    private List<RawCommand> rawCommands;
+
+    @Parameter(property = "commands", required = false)
+    private List<String> commands;
+
+    @Parameter( defaultValue = "${os.name}", property = "osName", required = false )
+    private String osName;
+
+    @Parameter(property = "rdlExecutableFile")
+    private File rdlExecutableFile;
+
+    @Parameter( defaultValue = "${project.build.sourceEncoding}", property = "sourceEncoding", required = true)
+    private String sourceEncoding;
+
+    @Parameter(property = "skip", defaultValue = "false")
+    private boolean skip;
+
+    @Component
+    private MavenProject mavenProject;
+
+    private File rdlScratchSpace;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) return;
+        rdlScratchSpace = new File(mavenProject.getBuild().getDirectory(), "rdl");
+        if (!rdlScratchSpace.mkdirs() && !rdlScratchSpace.exists()) {
+            throw new MojoExecutionException("Unable to create folder " + rdlScratchSpace);
+        }
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                install(new CommonModule());
+                bind(Log.class).toInstance(getLog());
+                bind(Path.class).annotatedWith(ScratchSpace.class).toInstance(rdlScratchSpace.toPath());
+                bind(Path.class).annotatedWith(RdlSources.class).toInstance(rdlDirectory.toPath());
+                bind(String.class).annotatedWith(OSName.class).toProvider(new OSNameProvider(osName));
+                bind(Charset.class).toInstance(Charset.forName(sourceEncoding != null ? sourceEncoding : "UTF-8"));
+            }
+
+            @Provides
+            @Singleton
+            public RdlExecutableFileProvider provideRdlExecutableFileProvider(
+                    @ScratchSpace Path scratchSpace,
+                    @OSName String osName) {
+                return new RdlExecutableFileProviderImpl(
+                        scratchSpace,
+                        osName,
+                        rdlExecutableFile == null ? null : rdlExecutableFile.toPath());
+            }
+
+
+        });
+        List<List<String>> cmdArgss;
+        if (commands.isEmpty() && rawCommands.isEmpty()) {
+            List<Path> rdlFiles = injector.getInstance(RdlFileFinder.class).findRdlFiles();
+            if (rdlFiles.size() == 0) {
+                throw new MojoExecutionException("No rdl files found.");
+            } else if (rdlFiles.size() > 1) {
+                throw new MojoExecutionException("Multiple rdl files found: " + rdlFiles);
+            }
+            String rdlFile = rdlFiles.get(0).toAbsolutePath().toString();
+            String outputFolder = Paths.get(mavenProject.getBuild().getDirectory(), "generated-sources", "rdl").toAbsolutePath().toString();
+            cmdArgss = new ArrayList<>();
+            for (String generator : Arrays.asList("java-model", "java-server")) {
+                cmdArgss.add(Arrays.asList("generate", "-o", outputFolder, generator, rdlFile));
+            }
+        } else {
+            cmdArgss = new ArrayList<>();
+            for (String command : commands) {
+                try {
+                    cmdArgss.add(Arrays.asList(CommandLineUtils.translateCommandline(command)));
+                } catch (Exception e) {
+                    throw new MojoExecutionException("Unable to parse command: " + command, e);
+                }
+            }
+            for (RawCommand rawCommand : rawCommands) {
+                if (rawCommand.arguments == null) {
+                    throw new MojoExecutionException("Raw command has no arguments");
+                }
+                cmdArgss.add(rawCommand.arguments);
+            }
+        }
+        String rdlBinary = injector.getInstance(RdlExecutableFileProvider.class).getRdlExecutableFile().toAbsolutePath().toString();
+        ProcessRunner processRunner = injector.getInstance(ProcessRunner.class);
+        for (List<String> cmdArgs : cmdArgss) {
+            int outputFlag = cmdArgs.indexOf("-o");
+            if (outputFlag >= 0 && outputFlag + 1 < cmdArgs.size()) {
+                mavenProject.addCompileSourceRoot(cmdArgs.get(outputFlag + 1));
+            }
+            List<String> fullCommand = new ArrayList<>(cmdArgs.size() + 1);
+            fullCommand.add(rdlBinary);
+            fullCommand.addAll(cmdArgs);
+            try {
+                processRunner.run(fullCommand);
+            } catch (IOException e) {
+                throw new MojoExecutionException("Unable to run rdl command.", e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/yahoo/rdl/maven/RawCommand.java
+++ b/src/main/java/com/yahoo/rdl/maven/RawCommand.java
@@ -1,0 +1,8 @@
+package com.yahoo.rdl.maven;
+
+import java.util.List;
+
+// © 2017 Yahoo! Inc
+public class RawCommand {
+    public List<String> arguments;
+}


### PR DESCRIPTION
Allows greater control to the command line arguments passed to the rdl binary. Since the plugin can now be used for something other than jax-rs-resource generation, I made a new goal called simply `generate`. The old goal `generate-jax-rs-resources` will continue to work, but does not have the same flexibility.

`StrSubstitutor` ended up being unnecessary, since everything could be done using maven properties.